### PR TITLE
working public client example with 1.19.0-nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,26 +9,16 @@ license = "MIT"
 repository = "https://github.com/KenanSulayman/gdax-client.git"
 
 [dependencies]
-aster = "0.36.0"
-base64 = "0.2.1"
-hyper = "0.9.14"
+base64 = "0.5.2"
+chrono = { version = "0.3.1", features = ["serde"] }
+hyper = "0.10.12"
+hyper-native-tls = "0.2.4"
 rust-crypto = "0.2.36"
-serde = "0.8.20"
-serde_derive = "0.8.20"
-serde_json = "0.8.4"
-time = "0.1.35"
-
-[dependencies.chrono]
-features = ["serde"]
-version = "0.2.25"
-
-[dependencies.uuid]
-features = ["serde"]
-version = "0.3.1"
+serde = "1.0.8"
+serde_derive = "1.0.8"
+serde_json = "1.0.2"
+time = "0.1.37"
+uuid = { version = "0.5.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
-env_logger = "0.3"
-
-[dev-dependencies.uuid]
-features = ["v4"]
-version = "0.3.1"
+env_logger = "0.4.3"


### PR DESCRIPTION
Here is a working example of public client with Rust 1.19.0 nightly. To make deserialization work I had to change some of the types in the structs. There may be a better way to do this with serde deserialize but I am not aware of any at this time.

```
$ rustc --version
rustc 1.19.0-nightly (554c685b0 2017-06-14)
